### PR TITLE
Address some of the `no_group_crossing` dependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1981,12 +1981,11 @@ module.exports = {
     {
       files: [
         // the following dependencies on AI-assistant will be solved when a proper Kibana AI assistant (platform) is created
-        'x-pack/plugins/observability_solution/infra/**',
         'x-pack/plugins/observability_solution/investigate_app/**',
         'x-pack/plugins/observability_solution/logs_shared/**',
         'x-pack/plugins/observability_solution/observability_ai_assistant_management/**',
 
-        // this plugin depends on visTypeTimeseries plugin (for TSVB viz) which is gonna be removed
+        // this plugin depends on visTypeTimeseries plugin (for TSVB viz) which is platform/private ATM
         'x-pack/plugins/observability_solution/infra/**',
 
         // TODO @kibana/operations

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1980,9 +1980,8 @@ module.exports = {
     },
     {
       files: [
-        // the following dependencies on AI-assistant will be solved when a proper Kibana AI assistant (platform) is created
+        // logsShared depends on o11y/private plugins, but platform plugins depend on it
         'x-pack/plugins/observability_solution/logs_shared/**',
-        'x-pack/plugins/observability_solution/observability_ai_assistant_management/**',
 
         // this plugin depends on visTypeTimeseries plugin (for TSVB viz) which is platform/private ATM
         'x-pack/plugins/observability_solution/infra/**',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1981,7 +1981,6 @@ module.exports = {
     {
       files: [
         // the following dependencies on AI-assistant will be solved when a proper Kibana AI assistant (platform) is created
-        'x-pack/plugins/observability_solution/investigate_app/**',
         'x-pack/plugins/observability_solution/logs_shared/**',
         'x-pack/plugins/observability_solution/observability_ai_assistant_management/**',
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1980,43 +1980,29 @@ module.exports = {
     },
     {
       files: [
-        'packages/kbn-reporting/common/**', // TODO @elastic/appex-sharedux - A package depending on a plugin: @kbn/screenshotting-plugin, can we move theser interfaces to a platform/shared package?
-        'packages/kbn-reporting/export_types/pdf_common/**', // TODO @elastic/appex-sharedux - A package depending on a plugin: @kbn/screenshotting-plugin, can we move theser interfaces to a platform/shared package?
-        'packages/kbn-reporting/export_types/pdf/**', // TODO @elastic/appex-sharedux - A package depending on a plugin: @kbn/screenshotting-plugin, can we move theser interfaces to a platform/shared package?
-        'packages/kbn-reporting/export_types/png_common/**', // TODO @elastic/appex-sharedux - A package depending on a plugin: @kbn/screenshotting-plugin, can we move theser interfaces to a platform/shared package?
-        'packages/kbn-reporting/export_types/png/**', // TODO @elastic/appex-sharedux - A package depending on a plugin: @kbn/screenshotting-plugin, can we move theser interfaces to a platform/shared package?
-        'packages/kbn-reporting/public/**', // TODO @elastic/appex-sharedux - A package depending on a plugin: @kbn/screenshotting-plugin, can we move theser interfaces to a platform/shared package?
-        'packages/kbn-reporting/server/**', // TODO @elastic/appex-sharedux - A package depending on a plugin: @kbn/screenshotting-plugin, can we move theser interfaces to a platform/shared package?
-        'packages/shared-ux/page/analytics_no_data/types/**',
-        'scripts/create_observability_rules.js', // TODO - is importing "@kbn/observability-alerting-test-data" (observability/private)
-        'src/cli_setup/**', // TODO @kibana/operations - is importing "@kbn/interactive-setup-plugin" (platform/private)
-        'src/dev/build/tasks/install_chromium.ts', // TODO @kibana/operations - is importing "@kbn/screenshotting-plugin" (platform/private)
-        'src/plugins/ai_assistant_management/selection/**',
-        'src/plugins/dashboard/**',
-        'src/plugins/discover/**',
-        'test/**',
-        'x-pack/examples/exploratory_view_example/**',
-        'x-pack/examples/screenshotting_example/**',
-        'x-pack/examples/ui_actions_enhanced_examples/**',
-        'x-pack/packages/security-solution/data_table/**',
-        'x-pack/plugins/aiops/**',
-        'x-pack/plugins/data_quality/**',
-        'x-pack/plugins/ingest_pipelines/**',
-        'x-pack/plugins/ml/**',
-        'x-pack/plugins/monitoring/**',
+        // the following dependencies on AI-assistant will be solved when a proper Kibana AI assistant (platform) is created
         'x-pack/plugins/observability_solution/infra/**',
-        'x-pack/plugins/observability_solution/inventory/**',
         'x-pack/plugins/observability_solution/investigate_app/**',
-        'x-pack/plugins/observability_solution/investigate/**',
         'x-pack/plugins/observability_solution/logs_shared/**',
-        'x-pack/plugins/observability_solution/metrics_data_access/**',
-        'x-pack/plugins/observability_solution/observability_ai_assistant_app/**',
         'x-pack/plugins/observability_solution/observability_ai_assistant_management/**',
-        'x-pack/plugins/observability_solution/observability/**',
-        'x-pack/plugins/observability_solution/slo/**',
-        'x-pack/plugins/observability_solution/synthetics/e2e/**',
+
+        // this plugin depends on visTypeTimeseries plugin (for TSVB viz) which is gonna be removed
+        'x-pack/plugins/observability_solution/infra/**',
+
+        // TODO @kibana/operations
+        'scripts/create_observability_rules.js', // is importing "@kbn/observability-alerting-test-data" (observability/private)
+        'src/cli_setup/**', // is importing "@kbn/interactive-setup-plugin" (platform/private)
+        'src/dev/build/tasks/install_chromium.ts', // is importing "@kbn/screenshotting-plugin" (platform/private)
+
+        // FIXME Using MAX_FILE_SIZE ui setting which is private (internal to fileUpload plugin)
+        'x-pack/plugins/ingest_pipelines/**',
+
+        // @kbn/osquery-plugin could be categorised as Security, but @kbn/infra-plugin (observability) depends on it!
         'x-pack/plugins/osquery/**',
-        'x-pack/plugins/search_assistant/**',
+
+        // For now, we keep the exception to let tests depend on anythying.
+        // Ideally, we need to classify the solution specific ones to reduce CI times
+        'test/**',
         'x-pack/test_serverless/**',
         'x-pack/test/**',
         'x-pack/test/plugin_functional/plugins/resolver_test/**',

--- a/packages/shared-ux/page/analytics_no_data/types/kibana.jsonc
+++ b/packages/shared-ux/page/analytics_no_data/types/kibana.jsonc
@@ -1,5 +1,7 @@
 {
   "type": "shared-browser",
   "id": "@kbn/shared-ux-page-analytics-no-data-types",
-  "owner": "@elastic/appex-sharedux"
+  "owner": "@elastic/appex-sharedux",
+  "group": "platform",
+  "visibility": "private"
 }

--- a/src/plugins/ai_assistant_management/selection/kibana.jsonc
+++ b/src/plugins/ai_assistant_management/selection/kibana.jsonc
@@ -4,7 +4,7 @@
   "owner": [
     "@elastic/obs-knowledge-team"
   ],
-  "group": "platform",
+  "group": "observability",
   "visibility": "private",
   "plugin": {
     "id": "aiAssistantManagementSelection",

--- a/x-pack/examples/exploratory_view_example/kibana.jsonc
+++ b/x-pack/examples/exploratory_view_example/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/exploratory-view-example-plugin",
   "owner": "@elastic/obs-ux-infra_services-team",
+  "group": "observability",
+  "visibility": "private",
   "plugin": {
     "id": "exploratoryViewExample",
     "server": false,

--- a/x-pack/examples/screenshotting_example/kibana.jsonc
+++ b/x-pack/examples/screenshotting_example/kibana.jsonc
@@ -2,6 +2,10 @@
   "type": "plugin",
   "id": "@kbn/screenshotting-example-plugin",
   "owner": "@elastic/appex-sharedux",
+  // This plugin is not meant to be referenced or imported
+  "visibility": "private",
+  // If cloned / used as an inspiration, please bear in mind that your plugin might belong to a specific solution group
+  "group": "platform",
   "description": "An example integration with the screenshotting plugin.",
   "plugin": {
     "id": "screenshottingExample",

--- a/x-pack/examples/ui_actions_enhanced_examples/kibana.jsonc
+++ b/x-pack/examples/ui_actions_enhanced_examples/kibana.jsonc
@@ -2,6 +2,10 @@
   "type": "plugin",
   "id": "@kbn/ui-actions-enhanced-examples-plugin",
   "owner": "@elastic/appex-sharedux",
+  // This plugin is not meant to be referenced or imported
+  "visibility": "private",
+  // If cloned / used as an inspiration, please bear in mind that your plugin might belong to a specific solution group
+  "group": "platform",
   "plugin": {
     "id": "uiActionsEnhancedExamples",
     "server": false,

--- a/x-pack/packages/security-solution/data_table/kibana.jsonc
+++ b/x-pack/packages/security-solution/data_table/kibana.jsonc
@@ -1,5 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/securitysolution-data-table",
-  "owner": "@elastic/security-threat-hunting-investigations"
+  "owner": "@elastic/security-threat-hunting-investigations",
+  "group": "security",
+  "visibility": "private"
 }

--- a/x-pack/plugins/dashboard_enhanced/kibana.jsonc
+++ b/x-pack/plugins/dashboard_enhanced/kibana.jsonc
@@ -5,7 +5,7 @@
     "@elastic/kibana-presentation"
   ],
   "group": "platform",
-  "visibility": "private",
+  "visibility": "shared",
   "plugin": {
     "id": "dashboardEnhanced",
     "browser": true,

--- a/x-pack/plugins/data_quality/kibana.jsonc
+++ b/x-pack/plugins/data_quality/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/data-quality-plugin",
   "owner": "@elastic/obs-ux-logs-team",
+  "group": "observability",
+  "visibility": "private",
   "plugin": {
     "id": "dataQuality",
     "server": true,

--- a/x-pack/plugins/monitoring/server/telemetry_collection/get_licenses.ts
+++ b/x-pack/plugins/monitoring/server/telemetry_collection/get_licenses.ts
@@ -7,7 +7,7 @@
 
 import { ElasticsearchClient } from '@kbn/core/server';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { ESLicense } from '@kbn/telemetry-collection-xpack-plugin/server';
+import type { LicenseGetLicenseInformation } from '@elastic/elasticsearch/lib/api/types';
 import { INDEX_PATTERN_ELASTICSEARCH, USAGE_FETCH_INTERVAL } from '../../common/constants';
 
 /**
@@ -18,7 +18,7 @@ export async function getLicenses(
   callCluster: ElasticsearchClient,
   timestamp: number,
   maxBucketSize: number
-): Promise<{ [clusterUuid: string]: ESLicense | undefined }> {
+): Promise<{ [clusterUuid: string]: LicenseGetLicenseInformation | undefined }> {
   const response = await fetchLicenses(callCluster, clusterUuids, timestamp, maxBucketSize);
   return handleLicenses(response);
 }

--- a/x-pack/plugins/monitoring/tsconfig.json
+++ b/x-pack/plugins/monitoring/tsconfig.json
@@ -19,7 +19,6 @@
     "@kbn/features-plugin",
     "@kbn/infra-plugin",
     "@kbn/licensing-plugin",
-    "@kbn/telemetry-collection-xpack-plugin",
     "@kbn/triggers-actions-ui-plugin",
     "@kbn/expect",
     "@kbn/i18n",

--- a/x-pack/plugins/observability_solution/infra/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/infra/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/infra-plugin",
   "owner": ["@elastic/obs-ux-logs-team", "@elastic/obs-ux-infra_services-team"],
+  "group": "observability",
+  "visibility": "private",
   "description": "This plugin visualizes data from Filebeat and Metricbeat, and integrates with other Observability solutions",
   "plugin": {
     "id": "infra",

--- a/x-pack/plugins/observability_solution/inventory/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/inventory/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/inventory-plugin",
   "owner": "@elastic/obs-ux-infra_services-team",
+  "group": "observability",
+  "visibility": "private",
   "plugin": {
     "id": "inventory",
     "server": true,

--- a/x-pack/plugins/observability_solution/investigate_app/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/investigate_app/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/investigate-app-plugin",
   "owner": "@elastic/obs-ux-management-team",
+  "group": "observability",
+  "visibility": "private",
   "plugin": {
     "id": "investigateApp",
     "server": true,

--- a/x-pack/plugins/observability_solution/metrics_data_access/server/lib/adapters/framework/adapter_types.ts
+++ b/x-pack/plugins/observability_solution/metrics_data_access/server/lib/adapters/framework/adapter_types.ts
@@ -17,7 +17,6 @@ import {
 } from '@kbn/data-plugin/server';
 import { PluginStart as DataViewsPluginStart } from '@kbn/data-views-plugin/server';
 import { HomeServerPluginSetup } from '@kbn/home-plugin/server';
-import { VisTypeTimeseriesSetup } from '@kbn/vis-type-timeseries-plugin/server';
 import { FeaturesPluginSetup } from '@kbn/features-plugin/server';
 import { SpacesPluginSetup } from '@kbn/spaces-plugin/server';
 import { PluginSetupContract as AlertingPluginContract } from '@kbn/alerting-plugin/server';
@@ -37,7 +36,6 @@ export interface InfraServerPluginSetupDeps {
   share: SharePluginSetup;
   spaces: SpacesPluginSetup;
   usageCollection: UsageCollectionSetup;
-  visTypeTimeseries: VisTypeTimeseriesSetup;
   ml?: MlPluginSetup;
   metricsDataAccess: MetricsDataPluginSetup;
 }

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/kibana.jsonc
@@ -4,8 +4,8 @@
   "owner": [
     "@elastic/obs-ai-assistant"
   ],
-  "group": "observability",
-  "visibility": "private",
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "observabilityAIAssistant",
     "browser": true,

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_management/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_management/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/observability-ai-assistant-management-plugin",
   "owner": "@elastic/obs-ai-assistant",
+  "group": "observability",
+  "visibility": "private",
   "plugin": {
     "id": "observabilityAiAssistantManagement",
     "server": true,

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_management/public/helpers/test_helper.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_management/public/helpers/test_helper.tsx
@@ -11,7 +11,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render as testLibRender } from '@testing-library/react';
 import { coreMock } from '@kbn/core/public/mocks';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
-import translations from '@kbn/translations-plugin/translations/ja-JP.json';
 import { observabilityAIAssistantPluginMock } from '@kbn/observability-ai-assistant-plugin/public/mock';
 import { RouterProvider } from '@kbn/typed-react-router-config';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
@@ -79,7 +78,7 @@ export const render = (
 
   return testLibRender(
     // @ts-ignore
-    <IntlProvider locale="en-US" messages={translations.messages}>
+    <IntlProvider locale="en-US">
       <RedirectToHomeIfUnauthorized coreStart={mergedCoreStartMock}>
         <KibanaContextProvider services={{ ...mergedCoreStartMock, ...startDeps }}>
           <AppContextProvider value={appContextValue}>

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_management/tsconfig.json
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_management/tsconfig.json
@@ -19,7 +19,6 @@
     "@kbn/core-chrome-browser",
     "@kbn/observability-ai-assistant-plugin",
     "@kbn/serverless",
-    "@kbn/translations-plugin",
     "@kbn/enterprise-search-plugin",
     "@kbn/management-settings-components-field-row",
     "@kbn/observability-shared-plugin",

--- a/x-pack/plugins/observability_solution/slo/public/utils/test_helper.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/utils/test_helper.tsx
@@ -13,7 +13,6 @@ import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { createObservabilityRuleTypeRegistryMock } from '@kbn/observability-plugin/public';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
-import translations from '@kbn/translations-plugin/translations/ja-JP.json';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render as testLibRender } from '@testing-library/react';
 import React from 'react';
@@ -43,7 +42,7 @@ const queryClient = new QueryClient({
 export const render = (component: React.ReactNode) => {
   return testLibRender(
     // @ts-ignore
-    <IntlProvider locale="en-US" messages={translations.messages}>
+    <IntlProvider locale="en-US">
       <KibanaContextProvider
         services={{
           ...core,

--- a/x-pack/plugins/observability_solution/slo/tsconfig.json
+++ b/x-pack/plugins/observability_solution/slo/tsconfig.json
@@ -17,7 +17,6 @@
     "@kbn/i18n-react",
     "@kbn/shared-ux-router",
     "@kbn/core",
-    "@kbn/translations-plugin",
     "@kbn/rule-data-utils",
     "@kbn/triggers-actions-ui-plugin",
     "@kbn/observability-plugin",

--- a/x-pack/plugins/observability_solution/synthetics/e2e/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/synthetics/e2e/kibana.jsonc
@@ -2,5 +2,7 @@
   "type": "test-helper",
   "id": "@kbn/synthetics-e2e",
   "owner": "@elastic/obs-ux-management-team",
+  "group": "observability",
+  "visibility": "private",
   "devOnly": true
 }

--- a/x-pack/plugins/screenshotting/kibana.jsonc
+++ b/x-pack/plugins/screenshotting/kibana.jsonc
@@ -5,7 +5,7 @@
     "@elastic/kibana-reporting-services"
   ],
   "group": "platform",
-  "visibility": "private",
+  "visibility": "shared",
   "description": "Kibana Screenshotting Plugin",
   "plugin": {
     "id": "screenshotting",

--- a/x-pack/plugins/search_assistant/kibana.jsonc
+++ b/x-pack/plugins/search_assistant/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/search-assistant",
   "owner": "@elastic/search-kibana",
+  "group": "search",
+  "visibility": "private",
   "description": "AI Assistant for Search",
   "plugin": {
     "id": "searchAssistant",

--- a/x-pack/plugins/telemetry_collection_xpack/server/index.ts
+++ b/x-pack/plugins/telemetry_collection_xpack/server/index.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-export type { ESLicense } from './telemetry_collection';
-
 //  This exports static code and TypeScript types,
 //  as well as, Kibana Platform `plugin()` initializer.
 

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecation_logs/es_deprecation_logs.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/es_deprecation_logs/es_deprecation_logs.test.tsx
@@ -165,9 +165,6 @@ describe('ES deprecation logs', () => {
               prepend: (url: string) => url,
             },
           },
-          plugins: {
-            infra: {},
-          },
         });
       });
 

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/helpers/app_context.mock.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/helpers/app_context.mock.ts
@@ -108,7 +108,6 @@ export const getAppContextMock = (kibanaVersion: SemVer) => ({
   },
   plugins: {
     share: shareMock,
-    infra: undefined,
     cloud: {
       ...cloudMock.createSetup(),
       isCloudEnabled: false,

--- a/x-pack/plugins/upgrade_assistant/kibana.jsonc
+++ b/x-pack/plugins/upgrade_assistant/kibana.jsonc
@@ -23,7 +23,6 @@
       "usageCollection",
       "cloud",
       "security",
-      "infra",
       "logsShared"
     ],
     "requiredBundles": [

--- a/x-pack/plugins/upgrade_assistant/kibana.jsonc
+++ b/x-pack/plugins/upgrade_assistant/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/upgrade-assistant-plugin",
   "owner": "@elastic/kibana-management",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "upgradeAssistant",
     "server": true,

--- a/x-pack/plugins/upgrade_assistant/public/plugin.ts
+++ b/x-pack/plugins/upgrade_assistant/public/plugin.ts
@@ -65,10 +65,6 @@ export class UpgradeAssistantUIPlugin
             plugins: {
               cloud,
               share,
-              // Infra plugin doesnt export anything as a public interface. So the only
-              // way we have at this stage for checking if the plugin is available or not
-              // is by checking if the startServices has the `infra` key.
-              infra: Object.hasOwn(plugins, 'infra') ? {} : undefined,
             },
             services: {
               core: coreStart,

--- a/x-pack/plugins/upgrade_assistant/public/types.ts
+++ b/x-pack/plugins/upgrade_assistant/public/types.ts
@@ -47,7 +47,6 @@ export interface AppDependencies {
   plugins: {
     cloud?: CloudSetup;
     share: SharePluginSetup;
-    infra: object | undefined;
   };
   services: {
     core: CoreStart;


### PR DESCRIPTION
## Summary

This PR relocates some plugins and packages that are incorrectly categorised, aiming at reducing inter-solution dependencies. It also fixes some incorrect import statements that introduce unnecessary dependencies with other components.