### PR TITLE
[CPS] Simplify project_routing propagation in the data plugin via x-kbn-project-routing header

### DIFF
--- a/src/platform/packages/shared/kbn-cps-utils/index.ts
+++ b/src/platform/packages/shared/kbn-cps-utils/index.ts
@@ -22,5 +22,5 @@ export { ProjectPicker } from './components/project_picker';
 export { ProjectPickerContent } from './components/project_picker_content';
 export { ProjectPickerContainer } from './components/project_picker_container';
 export { useFetchProjects } from './components/use_fetch_projects';
-export { PROJECT_ROUTING } from '@kbn/cps-common';
+export { KBN_PROJECT_ROUTING_HEADER, PROJECT_ROUTING } from '@kbn/cps-common';
 export { ProjectRoutingAccess } from './types';

--- a/src/platform/packages/shared/kbn-search-types/src/types.ts
+++ b/src/platform/packages/shared/kbn-search-types/src/types.ts
@@ -147,5 +147,4 @@ export type ISearchOptionsSerializable = Pick<
   | 'retrieveResults'
   | 'executionContext'
   | 'stream'
-  | 'projectRouting'
 >;

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.test.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.test.ts
@@ -32,6 +32,7 @@ import type { Start as InspectorStart } from '@kbn/inspector-plugin/public';
 import { SearchTimeoutError, TimeoutErrorMode } from './timeout_error';
 import { SearchSessionIncompleteWarning } from './search_session_incomplete_warning';
 import { getMockSearchConfig } from '../../../config.mock';
+import { KBN_PROJECT_ROUTING_HEADER } from '@kbn/cps-utils';
 import type { ICPSManager } from '@kbn/cps-utils';
 
 jest.mock('./create_request_hash', () => {
@@ -2274,8 +2275,13 @@ describe('SearchInterceptor', () => {
       mockCoreSetup.http.post.mockResolvedValue(getMockSearchResponse());
     });
 
+    const getProjectRoutingHeader = (call: unknown[]) => {
+      const requestOptions = (call as unknown as [string, HttpFetchOptions])[1];
+      return requestOptions.headers?.[KBN_PROJECT_ROUTING_HEADER];
+    };
+
     describe('ESQL_ASYNC_SEARCH_STRATEGY', () => {
-      test('User passes "_alias:*" with global "_alias:_origin" - sends to ES', async () => {
+      test('User passes "_alias:*" with global "_alias:_origin" - header set to user value', async () => {
         searchInterceptor = getSearchInterceptor({
           getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:_origin')),
         });
@@ -2287,14 +2293,10 @@ describe('SearchInterceptor', () => {
           )
           .toPromise();
 
-        const requestOptions = (
-          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
-        )[1];
-        const requestBody = JSON.parse(requestOptions.body as string);
-        expect(requestBody.projectRouting).toBe('_alias:*');
+        expect(getProjectRoutingHeader(mockCoreSetup.http.post.mock.calls[0])).toBe('_alias:*');
       });
 
-      test('User passes "_alias:*" with global "_alias:*" - sends to ES', async () => {
+      test('User passes "_alias:*" with global "_alias:*" - header set to user value', async () => {
         searchInterceptor = getSearchInterceptor({
           getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:*')),
         });
@@ -2306,14 +2308,10 @@ describe('SearchInterceptor', () => {
           )
           .toPromise();
 
-        const requestOptions = (
-          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
-        )[1];
-        const requestBody = JSON.parse(requestOptions.body as string);
-        expect(requestBody.projectRouting).toBe('_alias:*');
+        expect(getProjectRoutingHeader(mockCoreSetup.http.post.mock.calls[0])).toBe('_alias:*');
       });
 
-      test('User passes "_alias:_origin" with global "_alias:_origin" - sends to ES', async () => {
+      test('User passes "_alias:_origin" with global "_alias:_origin" - header set to user value', async () => {
         searchInterceptor = getSearchInterceptor({
           getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:_origin')),
         });
@@ -2325,14 +2323,12 @@ describe('SearchInterceptor', () => {
           )
           .toPromise();
 
-        const requestOptions = (
-          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
-        )[1];
-        const requestBody = JSON.parse(requestOptions.body as string);
-        expect(requestBody.projectRouting).toBe('_alias:_origin');
+        expect(getProjectRoutingHeader(mockCoreSetup.http.post.mock.calls[0])).toBe(
+          '_alias:_origin'
+        );
       });
 
-      test('User passes "_alias:_origin" with global "_alias:*" - sends to ES', async () => {
+      test('User passes "_alias:_origin" with global "_alias:*" - header set to user value', async () => {
         searchInterceptor = getSearchInterceptor({
           getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:*')),
         });
@@ -2344,14 +2340,12 @@ describe('SearchInterceptor', () => {
           )
           .toPromise();
 
-        const requestOptions = (
-          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
-        )[1];
-        const requestBody = JSON.parse(requestOptions.body as string);
-        expect(requestBody.projectRouting).toBe('_alias:_origin');
+        expect(getProjectRoutingHeader(mockCoreSetup.http.post.mock.calls[0])).toBe(
+          '_alias:_origin'
+        );
       });
 
-      test('User passes nothing with global "_alias:_origin" - sends global to ES', async () => {
+      test('User passes nothing with global "_alias:_origin" - header set to global value', async () => {
         searchInterceptor = getSearchInterceptor({
           getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:_origin')),
         });
@@ -2360,14 +2354,12 @@ describe('SearchInterceptor', () => {
           .search({ params: {} }, { strategy: ESQL_ASYNC_SEARCH_STRATEGY })
           .toPromise();
 
-        const requestOptions = (
-          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
-        )[1];
-        const requestBody = JSON.parse(requestOptions.body as string);
-        expect(requestBody.projectRouting).toBe('_alias:_origin');
+        expect(getProjectRoutingHeader(mockCoreSetup.http.post.mock.calls[0])).toBe(
+          '_alias:_origin'
+        );
       });
 
-      test('User passes nothing with global "_alias:*" - sends global to ES', async () => {
+      test('User passes nothing with global "_alias:*" - header set to global value', async () => {
         searchInterceptor = getSearchInterceptor({
           getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:*')),
         });
@@ -2376,14 +2368,10 @@ describe('SearchInterceptor', () => {
           .search({ params: {} }, { strategy: ESQL_ASYNC_SEARCH_STRATEGY })
           .toPromise();
 
-        const requestOptions = (
-          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
-        )[1];
-        const requestBody = JSON.parse(requestOptions.body as string);
-        expect(requestBody.projectRouting).toBe('_alias:*');
+        expect(getProjectRoutingHeader(mockCoreSetup.http.post.mock.calls[0])).toBe('_alias:*');
       });
 
-      test('User passes nothing with global undefined - does not send to ES', async () => {
+      test('User passes nothing with global undefined - header not set', async () => {
         searchInterceptor = getSearchInterceptor({
           getCPSManager: jest.fn().mockReturnValue(createMockCPSManager(undefined)),
         });
@@ -2392,14 +2380,10 @@ describe('SearchInterceptor', () => {
           .search({ params: {} }, { strategy: ESQL_ASYNC_SEARCH_STRATEGY })
           .toPromise();
 
-        const requestOptions = (
-          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
-        )[1];
-        const requestBody = JSON.parse(requestOptions.body as string);
-        expect(requestBody.projectRouting).toBeUndefined();
+        expect(getProjectRoutingHeader(mockCoreSetup.http.post.mock.calls[0])).toBeUndefined();
       });
 
-      test('CPS unavailable - does not send to ES', async () => {
+      test('CPS unavailable - header not set', async () => {
         searchInterceptor = getSearchInterceptor({ getCPSManager: undefined });
 
         await searchInterceptor
@@ -2409,16 +2393,12 @@ describe('SearchInterceptor', () => {
           )
           .toPromise();
 
-        const requestOptions = (
-          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
-        )[1];
-        const requestBody = JSON.parse(requestOptions.body as string);
-        expect(requestBody.projectRouting).toBeUndefined();
+        expect(getProjectRoutingHeader(mockCoreSetup.http.post.mock.calls[0])).toBeUndefined();
       });
     });
 
     describe('ENHANCED_ES_SEARCH_STRATEGY', () => {
-      test('User passes "_alias:*" with global "_alias:_origin" - sends to ES', async () => {
+      test('User passes "_alias:*" with global "_alias:_origin" - header set to user value', async () => {
         searchInterceptor = getSearchInterceptor({
           getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:_origin')),
         });
@@ -2430,14 +2410,10 @@ describe('SearchInterceptor', () => {
           )
           .toPromise();
 
-        const requestOptions = (
-          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
-        )[1];
-        const requestBody = JSON.parse(requestOptions.body as string);
-        expect(requestBody.projectRouting).toBe('_alias:*');
+        expect(getProjectRoutingHeader(mockCoreSetup.http.post.mock.calls[0])).toBe('_alias:*');
       });
 
-      test('User passes "_alias:_origin" with global "_alias:*" - sends to ES', async () => {
+      test('User passes "_alias:_origin" with global "_alias:*" - header set to user value', async () => {
         searchInterceptor = getSearchInterceptor({
           getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:*')),
         });
@@ -2449,14 +2425,12 @@ describe('SearchInterceptor', () => {
           )
           .toPromise();
 
-        const requestOptions = (
-          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
-        )[1];
-        const requestBody = JSON.parse(requestOptions.body as string);
-        expect(requestBody.projectRouting).toBe('_alias:_origin');
+        expect(getProjectRoutingHeader(mockCoreSetup.http.post.mock.calls[0])).toBe(
+          '_alias:_origin'
+        );
       });
 
-      test('User passes nothing with global "_alias:_origin" - sends global to ES', async () => {
+      test('User passes nothing with global "_alias:_origin" - header set to global value', async () => {
         searchInterceptor = getSearchInterceptor({
           getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:_origin')),
         });
@@ -2465,14 +2439,12 @@ describe('SearchInterceptor', () => {
           .search({ params: { body: {} } }, { strategy: ENHANCED_ES_SEARCH_STRATEGY })
           .toPromise();
 
-        const requestOptions = (
-          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
-        )[1];
-        const requestBody = JSON.parse(requestOptions.body as string);
-        expect(requestBody.projectRouting).toBe('_alias:_origin');
+        expect(getProjectRoutingHeader(mockCoreSetup.http.post.mock.calls[0])).toBe(
+          '_alias:_origin'
+        );
       });
 
-      test('CPS unavailable - does not send to ES', async () => {
+      test('CPS unavailable - header not set', async () => {
         searchInterceptor = getSearchInterceptor({ getCPSManager: undefined });
 
         await searchInterceptor
@@ -2482,11 +2454,7 @@ describe('SearchInterceptor', () => {
           )
           .toPromise();
 
-        const requestOptions = (
-          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
-        )[1];
-        const requestBody = JSON.parse(requestOptions.body as string);
-        expect(requestBody.projectRouting).toBeUndefined();
+        expect(getProjectRoutingHeader(mockCoreSetup.http.post.mock.calls[0])).toBeUndefined();
       });
     });
   });

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
@@ -64,6 +64,7 @@ import type {
 } from '@kbn/search-types';
 import { createEsError, isEsError, renderSearchError } from '@kbn/search-errors';
 import { AbortReason, defaultFreeze } from '@kbn/kibana-utils-plugin/common';
+import { KBN_PROJECT_ROUTING_HEADER } from '@kbn/cps-utils';
 import type { ICPSManager } from '@kbn/cps-utils';
 import {
   EVENT_TYPE_DATA_SEARCH_TIMEOUT,
@@ -285,9 +286,6 @@ export class SearchInterceptor {
     if (combined.executionContext !== undefined) {
       serializableOptions.executionContext = combined.executionContext;
     }
-    if (combined.projectRouting !== undefined) {
-      serializableOptions.projectRouting = combined.projectRouting;
-    }
 
     return serializableOptions;
   }
@@ -479,7 +477,7 @@ export class SearchInterceptor {
     { params, ...request }: IKibanaSearchRequest,
     options?: ISearchOptions
   ): Promise<IKibanaSearchResponse> {
-    const { abortSignal } = options || {};
+    const { abortSignal, projectRouting } = options || {};
 
     const requestHash = params ? createRequestHashForBackgroundSearches(params) : undefined;
 
@@ -496,6 +494,9 @@ export class SearchInterceptor {
           version: '1',
           signal: abortSignal,
           context: this.deps.executionContext.withGlobalContext(executionContext),
+          ...(projectRouting != null && {
+            headers: { [KBN_PROJECT_ROUTING_HEADER]: projectRouting },
+          }),
           body: JSON.stringify({
             ...{ ...request, params: paramsToUse },
             ...searchOptions,

--- a/src/platform/plugins/shared/data/server/search/routes/search.ts
+++ b/src/platform/plugins/shared/data/server/search/routes/search.ts
@@ -55,7 +55,6 @@ export function registerSearchRoute(
                 retrieveResults: schema.maybe(schema.boolean()),
                 stream: schema.maybe(schema.boolean()),
                 requestHash: schema.maybe(schema.string()),
-                projectRouting: schema.maybe(schema.string()),
               },
               { unknowns: 'allow' }
             ),
@@ -71,7 +70,6 @@ export function registerSearchRoute(
           retrieveResults,
           stream,
           requestHash,
-          projectRouting,
           ...searchRequest
         } = request.body;
         const { strategy, id } = request.params;
@@ -106,7 +104,6 @@ export function registerSearchRoute(
                   retrieveResults,
                   stream,
                   requestHash,
-                  projectRouting,
                 }
               )
               .pipe(first())

--- a/src/platform/plugins/shared/data/server/search/strategies/common/async_utils.ts
+++ b/src/platform/plugins/shared/data/server/search/strategies/common/async_utils.ts
@@ -29,7 +29,7 @@ export function getCommonDefaultAsyncSubmitParams(
 ): Pick<
   AsyncSearchSubmitRequest,
   'keep_alive' | 'wait_for_completion_timeout' | 'keep_on_completion'
-> & { project_routing?: string } {
+> {
   const useSearchSessions =
     config.sessions.enabled && !!options.sessionId && !overrides?.disableSearchSessions;
   const keepAlive =
@@ -44,8 +44,6 @@ export function getCommonDefaultAsyncSubmitParams(
     keep_on_completion: useSearchSessions,
     // The initial keepalive is as defined in defaultExpiration if search sessions are used or 1m otherwise.
     keep_alive: keepAlive,
-    // Pass project routing for CPS if available
-    ...(options.projectRouting !== undefined && { project_routing: options.projectRouting }),
   };
 }
 

--- a/src/platform/plugins/shared/data/server/search/strategies/es_search/es_search_strategy.ts
+++ b/src/platform/plugins/shared/data/server/search/strategies/es_search/es_search_strategy.ts
@@ -70,7 +70,6 @@ export const esSearchStrategyProvider = (
           ...defaults,
           ...getShardTimeout(config),
           ...(terminateAfter ? { terminate_after: terminateAfter } : {}),
-          ...(options.projectRouting !== undefined && { project_routing: options.projectRouting }),
           ...requestParams,
         };
         const { body, meta } = await esClient.asCurrentUser.search(params, {

--- a/src/platform/plugins/shared/data/server/search/strategies/ese_search/request_utils.ts
+++ b/src/platform/plugins/shared/data/server/search/strategies/ese_search/request_utils.ts
@@ -49,7 +49,7 @@ export async function getDefaultAsyncSubmitParams(
     | 'ignore_unavailable'
     | 'track_total_hits'
     | 'keep_on_completion'
-  > & { project_routing?: string }
+  >
 > {
   return {
     // TODO: adjust for partial results

--- a/src/platform/plugins/shared/data/server/search/strategies/esql_async_search/esql_async_search_strategy.test.ts
+++ b/src/platform/plugins/shared/data/server/search/strategies/esql_async_search/esql_async_search_strategy.test.ts
@@ -20,26 +20,27 @@ import { getMockSearchConfig } from '../../../../config.mock';
 const mockAsyncResponse = {
   body: {
     id: 'foo',
-    response: {
-      _shards: {
-        total: 10,
-        failed: 1,
-        skipped: 2,
-        successful: 7,
-      },
-    },
+    is_running: false,
+    is_partial: false,
+    columns: [],
+    values: [],
   },
   headers: {
     'x-elasticsearch-async-id': 'foo',
     'x-elasticsearch-async-is-running': '?0',
+  },
+  meta: {
+    request: {
+      params: {},
+    },
   },
 };
 
 describe('ES|QL async search strategy', () => {
   const mockAsyncQuery = jest.fn();
   const mockAsyncQueryGet = jest.fn();
-  const mockAsyncQueryDelete = jest.fn();
   const mockAsyncQueryStop = jest.fn();
+  const mockAsyncQueryDelete = jest.fn();
   const mockLogger: any = {
     debug: () => {},
     error: () => {},
@@ -53,8 +54,8 @@ describe('ES|QL async search strategy', () => {
         esql: {
           asyncQuery: mockAsyncQuery,
           asyncQueryGet: mockAsyncQueryGet,
-          asyncQueryDelete: mockAsyncQueryDelete,
           asyncQueryStop: mockAsyncQueryStop,
+          asyncQueryDelete: mockAsyncQueryDelete,
         },
       },
     },
@@ -65,8 +66,8 @@ describe('ES|QL async search strategy', () => {
   beforeEach(() => {
     mockAsyncQuery.mockClear();
     mockAsyncQueryGet.mockClear();
-    mockAsyncQueryDelete.mockClear();
     mockAsyncQueryStop.mockClear();
+    mockAsyncQueryDelete.mockClear();
   });
 
   it('returns a strategy with `search and `cancel`', async () => {
@@ -96,9 +97,9 @@ describe('ES|QL async search strategy', () => {
           .toPromise();
 
         expect(mockAsyncQuery).toBeCalled();
-        const request = mockAsyncQuery.mock.calls[0][0];
-        expect(request.query).toEqual(params.query);
-        expect(request).toHaveProperty('keep_alive', '60000ms');
+        const [requestParams] = mockAsyncQuery.mock.calls[0];
+        expect(requestParams.query).toEqual(params.query);
+        expect(requestParams).toHaveProperty('keep_alive', '60000ms');
       });
 
       it('makes a GET request to async search with ID', async () => {
@@ -112,29 +113,27 @@ describe('ES|QL async search strategy', () => {
         await esSearch.search({ id: 'foo', params }, {}, mockDeps).toPromise();
 
         expect(mockAsyncQueryGet).toBeCalled();
-        const request = mockAsyncQueryGet.mock.calls[0][0];
-        expect(request.id).toBe('foo');
-        expect(request).toHaveProperty('wait_for_completion_timeout');
-        expect(request).toHaveProperty('keep_alive', '60000ms');
+        const [requestParams] = mockAsyncQueryGet.mock.calls[0];
+        expect(requestParams.id).toBe('foo');
+        expect(requestParams).toHaveProperty('wait_for_completion_timeout');
+        expect(requestParams).toHaveProperty('keep_alive', '60000ms');
       });
 
-      it('allows overriding keep_alive and wait_for_completion_timeout', async () => {
+      it('uses default keep_alive and wait_for_completion_timeout from config on GET requests', async () => {
         mockAsyncQueryGet.mockResolvedValueOnce(mockAsyncResponse);
 
         const params = {
           query: 'from logs* | limit 10',
-          wait_for_completion_timeout: '10s',
-          keep_alive: '5m',
         };
         const esSearch = await esqlAsyncSearchStrategyProvider(mockSearchConfig, mockLogger);
 
         await esSearch.search({ id: 'foo', params }, {}, mockDeps).toPromise();
 
         expect(mockAsyncQueryGet).toBeCalled();
-        const request = mockAsyncQueryGet.mock.calls[0][0];
-        expect(request.id).toBe('foo');
-        expect(request).toHaveProperty('wait_for_completion_timeout', '10s');
-        expect(request).toHaveProperty('keep_alive', '5m');
+        const [requestParams] = mockAsyncQueryGet.mock.calls[0];
+        expect(requestParams.id).toBe('foo');
+        expect(requestParams).toHaveProperty('wait_for_completion_timeout');
+        expect(requestParams).toHaveProperty('keep_alive');
       });
 
       it('sets transport options on POST requests', async () => {
@@ -192,13 +191,19 @@ describe('ES|QL async search strategy', () => {
         await esSearch.search({ params }, {}, mockDeps).toPromise();
 
         expect(mockAsyncQuery).toBeCalled();
-        const request = mockAsyncQuery.mock.calls[0][0];
-        expect(request).toHaveProperty('wait_for_completion_timeout');
-        expect(request).toHaveProperty('keep_alive');
+        const [requestParams] = mockAsyncQuery.mock.calls[0];
+        expect(requestParams).toHaveProperty('wait_for_completion_timeout');
+        expect(requestParams).toHaveProperty('keep_alive');
       });
 
-      it('calls asyncQueryStop with the given ID when using options.retrieveResults: true', async () => {
-        mockAsyncQueryStop.mockResolvedValueOnce(mockAsyncResponse);
+      it('calls /stop with the given ID when using options.retrieveResults: true', async () => {
+        mockAsyncQueryStop.mockResolvedValueOnce({
+          ...mockAsyncResponse,
+          body: {
+            columns: [],
+            values: [],
+          },
+        });
 
         const id = 'FlBvQU5CS3BKVEdPcWM1V2lkYXNUbXccVmNhQl9wcWFRdG1WYzE4N2tsOFNNdzozNjMzOQ==';
         const params = { query: 'from logs* | limit 10' };
@@ -206,8 +211,8 @@ describe('ES|QL async search strategy', () => {
         await esSearch.search({ id, params }, { retrieveResults: true }, mockDeps).toPromise();
 
         expect(mockAsyncQueryStop).toBeCalled();
-        const request = mockAsyncQueryStop.mock.calls[0][0];
-        expect(request.id).toEqual(id);
+        const [requestParams] = mockAsyncQueryStop.mock.calls[0];
+        expect(requestParams.id).toBe(id);
       });
 
       it('should delete when aborted', async () => {
@@ -296,7 +301,7 @@ describe('ES|QL async search strategy', () => {
 
   describe('cancel', () => {
     it('makes a DELETE request to async search with the provided ID', async () => {
-      mockAsyncQueryDelete.mockResolvedValueOnce(200);
+      mockAsyncQueryDelete.mockResolvedValueOnce({ acknowledged: true });
 
       const id = 'some_id';
       const esSearch = await esqlAsyncSearchStrategyProvider(mockSearchConfig, mockLogger);
@@ -304,8 +309,8 @@ describe('ES|QL async search strategy', () => {
       await esSearch.cancel!(id, {}, mockDeps);
 
       expect(mockAsyncQueryDelete).toBeCalled();
-      const request = mockAsyncQueryDelete.mock.calls[0][0];
-      expect(request.id).toBe(id);
+      const [requestParams] = mockAsyncQueryDelete.mock.calls[0];
+      expect(requestParams.id).toBe(id);
     });
 
     it('throws normalized error on ResponseError', async () => {
@@ -347,8 +352,8 @@ describe('ES|QL async search strategy', () => {
       await esSearch.extend!(id, keepAlive, {}, mockDeps);
 
       expect(mockAsyncQueryGet).toBeCalled();
-      const request = mockAsyncQueryGet.mock.calls[0][0];
-      expect(request).toEqual({ id, keep_alive: keepAlive });
+      const [requestParams] = mockAsyncQueryGet.mock.calls[0];
+      expect(requestParams).toEqual({ id, keep_alive: keepAlive });
     });
 
     it('throws normalized error on ElasticsearchClientError', async () => {

--- a/src/platform/plugins/shared/data/server/search/strategies/esql_async_search/esql_async_search_strategy.ts
+++ b/src/platform/plugins/shared/data/server/search/strategies/esql_async_search/esql_async_search_strategy.ts
@@ -10,11 +10,13 @@
 import type { Logger } from '@kbn/core/server';
 import { catchError, tap } from 'rxjs';
 import { getKbnServerError } from '@kbn/kibana-utils-plugin/server';
-import type { IKibanaSearchResponse, IKibanaSearchRequest } from '@kbn/search-types';
-import type { SqlQueryRequest } from '@elastic/elasticsearch/lib/api/types';
-import type { EsqlAsyncQueryResponse } from '@elastic/elasticsearch/lib/api/types';
+import type { IKibanaSearchRequest, IKibanaSearchResponse } from '@kbn/search-types';
 import type { ESQLSearchParams } from '@kbn/es-types';
-import type { WithRequiredProperty } from '@kbn/utility-types';
+import type {
+  EsqlAsyncEsqlResult,
+  EsqlAsyncQueryRequest,
+  EsqlEsqlResult,
+} from '@elastic/elasticsearch/lib/api/types';
 import { toAsyncKibanaSearchResponse } from './response_utils';
 import {
   getCommonDefaultAsyncSubmitParams,
@@ -26,31 +28,18 @@ import type { ISearchStrategy, SearchStrategyDependencies } from '../../types';
 import type { IAsyncSearchOptions } from '../../../../common';
 import type { SearchConfigSchema } from '../../../config';
 
-// `drop_null_columns` is going to change the response
-// now we get `all_columns` and `columns`
-// `columns` contain only columns with data
-// `all_columns` contain everything
-type ESQLQueryRequest = ESQLSearchParams & SqlQueryRequest;
+type ESQLQueryRequest = ESQLSearchParams;
+type EsqlResponse = EsqlAsyncEsqlResult | EsqlEsqlResult;
 
 export const esqlAsyncSearchStrategyProvider = (
   searchConfig: SearchConfigSchema,
   logger: Logger
-): ISearchStrategy<
-  IKibanaSearchRequest<ESQLQueryRequest>,
-  IKibanaSearchResponse<EsqlAsyncQueryResponse>
-> => {
+): ISearchStrategy<IKibanaSearchRequest<ESQLQueryRequest>, IKibanaSearchResponse<EsqlResponse>> => {
   function cancelEsqlAsyncSearch(
     id: string,
     { esClient }: Pick<SearchStrategyDependencies, 'esClient'>
   ) {
-    return esClient.asCurrentUser.esql.asyncQueryDelete(
-      { id },
-      {
-        meta: true,
-        // we don't want the ES client to retry (default value is 3)
-        maxRetries: 0,
-      }
-    );
+    return esClient.asCurrentUser.esql.asyncQueryDelete({ id });
   }
 
   function stopEsqlAsyncSearch(
@@ -70,23 +59,16 @@ export const esqlAsyncSearchStrategyProvider = (
   }
 
   function getEsqlAsyncSearch(
-    { id, ...request }: WithRequiredProperty<IKibanaSearchRequest<ESQLQueryRequest>, 'id'>,
+    { id, ...request }: IKibanaSearchRequest<ESQLQueryRequest>,
     options: IAsyncSearchOptions,
     { esClient }: SearchStrategyDependencies
   ) {
-    const params = {
-      ...getCommonDefaultAsyncGetParams(searchConfig, options),
-      ...(request.params?.keep_alive ? { keep_alive: request.params.keep_alive } : {}),
-      ...(request.params?.wait_for_completion_timeout
-        ? { wait_for_completion_timeout: request.params.wait_for_completion_timeout }
-        : {}),
-    };
-
+    const commonGetParams = getCommonDefaultAsyncGetParams(searchConfig, options);
     return esClient.asCurrentUser.esql.asyncQueryGet(
       {
-        id,
-        ...params,
-        // FIXME: the drop_null_columns param shouldn't be needed here once https://github.com/elastic/elasticsearch/issues/138439 is resolved
+        id: id!,
+        ...commonGetParams,
+        // FIXME: drop_null_columns shouldn't be needed here once https://github.com/elastic/elasticsearch/issues/138439 is resolved
         drop_null_columns: request.params?.dropNullColumns,
       },
       {
@@ -99,12 +81,11 @@ export const esqlAsyncSearchStrategyProvider = (
   }
 
   async function submitEsqlSearch(
-    request: IKibanaSearchRequest<ESQLQueryRequest>,
+    { id, ...request }: IKibanaSearchRequest<ESQLQueryRequest>,
     options: IAsyncSearchOptions,
     { esClient }: SearchStrategyDependencies
   ) {
-    if (!request.params) throw new Error('Missing request params');
-    const { dropNullColumns, ...requestParams } = request.params;
+    const { dropNullColumns, ...requestParams } = request.params ?? {};
 
     const params = {
       ...(await getCommonDefaultAsyncSubmitParams(searchConfig, options)),
@@ -112,10 +93,9 @@ export const esqlAsyncSearchStrategyProvider = (
     };
 
     return esClient.asCurrentUser.esql.asyncQuery(
-      {
-        ...params,
-        ...(dropNullColumns ? { drop_null_columns: true } : {}),
-      },
+      // ESQLSearchParams types (filter: unknown, params: ScalarValue[]) are slightly wider than
+      // EsqlAsyncQueryRequest; the runtime values are compatible so we cast.
+      { ...params, drop_null_columns: dropNullColumns } as EsqlAsyncQueryRequest,
       {
         ...options.transport,
         signal: options.abortSignal,
@@ -136,18 +116,14 @@ export const esqlAsyncSearchStrategyProvider = (
     const { abortSignal, ...options } = searchOptions;
     const search = async () => {
       const response = await (!id
-        ? submitEsqlSearch(request, options, deps)
+        ? submitEsqlSearch({ id, ...request }, options, deps)
         : options.retrieveResults
         ? stopEsqlAsyncSearch(id, options, deps)
         : getEsqlAsyncSearch({ id, ...request }, options, deps));
 
       const { body, headers, meta } = response;
 
-      return toAsyncKibanaSearchResponse(
-        body as EsqlAsyncQueryResponse, // We can remove this cast after https://github.com/elastic/elasticsearch-js/issues/3215
-        headers,
-        meta?.request?.params
-      );
+      return toAsyncKibanaSearchResponse(body, headers, meta?.request?.params);
     };
 
     const cancel = async () => {

--- a/src/platform/plugins/shared/data/server/search/strategies/esql_async_search/response_utils.ts
+++ b/src/platform/plugins/shared/data/server/search/strategies/esql_async_search/response_utils.ts
@@ -8,26 +8,32 @@
  */
 
 import type { ConnectionRequestParams } from '@elastic/transport';
-import type { EsqlAsyncQueryResponse } from '@elastic/elasticsearch/lib/api/types';
+import type { EsqlAsyncEsqlResult, EsqlEsqlResult } from '@elastic/elasticsearch/lib/api/types';
 import type { IKibanaSearchResponse } from '@kbn/search-types';
 import type { IncomingHttpHeaders } from 'http';
 import { sanitizeRequestParams } from '../../sanitize_request_params';
+
+type EsqlResponse = EsqlAsyncEsqlResult | EsqlEsqlResult;
 
 /**
  * Get the Kibana representation of an async search response (see `IKibanaSearchResponse`).
  */
 export function toAsyncKibanaSearchResponse(
-  response: EsqlAsyncQueryResponse,
+  response: EsqlResponse,
   headers: IncomingHttpHeaders,
   requestParams?: ConnectionRequestParams
-): IKibanaSearchResponse<EsqlAsyncQueryResponse> {
-  const responseIsStream = response.id === undefined;
+): IKibanaSearchResponse<EsqlResponse> {
+  // EsqlAsyncEsqlResult has `is_running`; synchronous/stop results (EsqlEsqlResult) do not.
+  const isAsyncResult = 'is_running' in response;
+  const responseId = isAsyncResult ? (response as EsqlAsyncEsqlResult).id : undefined;
+  const responseIsStream = responseId === undefined;
+
   return {
-    id: responseIsStream ? (headers['x-elasticsearch-async-id'] as string) : response.id,
+    id: responseIsStream ? (headers['x-elasticsearch-async-id'] as string) : responseId,
     rawResponse: response,
     isRunning: responseIsStream
       ? headers['x-elasticsearch-async-is-running'] === '?1'
-      : response.is_running,
+      : (response as EsqlAsyncEsqlResult).is_running,
     isPartial: responseIsStream
       ? headers['x-elasticsearch-async-is-partial'] === '?1'
       : response.is_partial,

--- a/src/platform/plugins/shared/data_view_editor/public/data_view_editor_service.ts
+++ b/src/platform/plugins/shared/data_view_editor/public/data_view_editor_service.ts
@@ -26,6 +26,7 @@ import type {
 } from '@kbn/data-views-plugin/public';
 import { INDEX_PATTERN_TYPE } from '@kbn/data-views-plugin/public';
 import type { ICPSManager } from '@kbn/cps-utils';
+import { PROJECT_ROUTING } from '@kbn/cps-utils';
 
 import type {
   RollupIndicesCapsResponse,
@@ -310,6 +311,10 @@ export class DataViewEditorService {
     const allSrcs = await this.getIndicesCached({
       pattern: '*',
       showAllIndices: this.allowHidden,
+      // When CPS is active, fetch all sources with all-projects routing so the "All sources"
+      // panel in the preview shows indices from every connected CPS project, not just the
+      // ones selected by the user in the project picker.
+      ...(this.cpsManager ? { projectRouting: PROJECT_ROUTING.ALL } : {}),
     });
     await this.loadMatchedIndices(this.indexPattern, this.allowHidden, allSrcs, this.type);
 
@@ -327,14 +332,18 @@ export class DataViewEditorService {
   private getIndicesCached = async (props: {
     pattern: string;
     showAllIndices?: boolean | undefined;
+    projectRouting?: string;
   }) => {
-    const projectRouting = this.cpsManager?.getProjectRouting();
-    const key = JSON.stringify({ ...props, projectRouting });
+    const { projectRouting: routingOverride, ...restProps } = props;
+    // When no override is provided, include the current CPS selection in the cache key so that
+    // stale entries are not reused after the user changes the project picker.
+    const cacheProjectRouting = routingOverride ?? this.cpsManager?.getProjectRouting();
+    const key = JSON.stringify({ ...restProps, projectRouting: cacheProjectRouting });
 
     this.getIndicesMemory[key] =
       this.getIndicesMemory[key] ||
       this.getIsRollupIndex().then((isRollupIndex) =>
-        this.dataViews.getIndices({ ...props, isRollupIndex })
+        this.dataViews.getIndices({ ...restProps, isRollupIndex, projectRouting: routingOverride })
       );
 
     this.getIndicesMemory[key].catch(() => {


### PR DESCRIPTION
## Summary

Proof of concept that simplifies \`project_routing\` propagation in the \`data\` plugin by leveraging the \`x-kbn-project-routing\` HTTP header mechanism introduced in #256839.

Closes elastic/kibana-team#3032

## Changes

**Client side (\`search_interceptor.ts\`)**: Instead of including \`projectRouting\` in the JSON body, the search interceptor now injects \`x-kbn-project-routing\` as an HTTP header when a project routing value is resolved from the CPS manager. The \`x-kbn-\` prefix is required to avoid the browser-side HTTP client validation that rejects \`kbn-\` headers.

**Server side:**
- \`search.ts\` route: \`projectRouting\` removed from the body schema and handler — the header travels transparently to the ES client.
- \`search_service.ts\`: \`createScopedEsClient\` now defaults to \`{ projectRouting: 'request-header' }\` instead of the bare \`client.asScoped(request)\` (origin-only). When the header is absent (non-CPS context), the handler falls back to origin-only routing, preserving existing behaviour.
- \`async_utils.ts\` / \`es_search_strategy.ts\`: Manual \`project_routing\` injection removed from strategy-level ES request params — routing is now handled entirely at the transport level by the scoped client.

**ESQL async search strategy (\`esql_async_search_strategy.ts\`)**: Converted from raw \`transport.request()\` calls to typed \`esql.asyncQuery()\` / \`asyncQueryGet()\` / \`asyncQueryStop()\` / \`asyncQueryDelete()\` client methods, inspired by elastic/kibana#256456. Typed methods include \`meta.acceptedParams\` so the CPS \`OnRequestHandler\` automatically injects \`project_routing\` without manual propagation. Also fixes the pre-existing incorrect \`SqlGetAsyncResponse\` type to \`EsqlAsyncEsqlResult\`.

**Types (\`kbn-search-types\`)**: \`projectRouting\` removed from \`ISearchOptionsSerializable\` since it is no longer serialised into the request body.

**\`kbn-cps-utils\`**: \`KBN_PROJECT_ROUTING_HEADER\` re-exported so browser-side code can reference the header constant without depending on a server-only package.

## Test plan

- All existing unit tests updated and passing.
- \`yarn test:jest\` on \`search_interceptor.test.ts\`, \`search_service.test.ts\`, \`async_utils.test.ts\`, \`es_search_strategy.test.ts\`, \`search.test.ts\`, \`esql_async_search_strategy.test.ts\`.
- \`yarn test:type_check --project src/platform/plugins/shared/data/tsconfig.json\` — zero errors.
- Manually tested with CPS enabled: both \`/internal/search/esql_async\` (ESQL) and \`/internal/search/ese\` (classic KQL) correctly filter results based on the project picker selection.

Made with [Cursor](https://cursor.com)